### PR TITLE
Filter patrolled edits

### DIFF
--- a/src/ScoredRevisions.js
+++ b/src/ScoredRevisions.js
@@ -97,20 +97,32 @@
 			linkSelector = conf.wgCanonicalSpecialPageName === 'Contributions' ||
 				conf.wgAction === 'history' ?
 				'a.mw-changeslist-date' :
-				'a';
+				'a',
+			filterPatrolled = $('.unpatrolled').length;
+
 		if ( conf.wgIsArticle && conf.wgAction === 'view' ) {
 			changes[ conf.wgCurRevisionId ] = $( '#ca-history a' );
 			return dfd.resolve( [ conf.wgCurRevisionId ] ).promise();
 		}
 		$( container )
 			.find( rowSelector )
-			.each( function () {
-				var $row = $( this ),
-					id, pageid;
+			.filter( function() {
+				var $row = $( this );
 				if ( $row.hasClass( 'wikibase-edit' ) ) {
 					// Skip external edits from Wikidata
 					return false;
 				}
+				if ( filterPatrolled && $row.has('.unpatrolled').length === 0 )
+				{
+					// skip patrolled edits
+					return false;
+				}
+				return true;
+			})
+			.each( function () {
+				var $row = $( this ),
+					id, pageid;
+
 				$row.find( linkSelector )
 					.each( function () {
 						var href = $( this ).attr( 'href' );


### PR DESCRIPTION
1. This patch filters already patrolled edits for users with patrol right.
   (based on the assumption that at least one .unpatrolled object appear)
2. bugfix - use filter instead of each which cause early termination.
